### PR TITLE
updating fedora 23 ami to newest one

### DIFF
--- a/images/consul/v1/template.json
+++ b/images/consul/v1/template.json
@@ -9,7 +9,7 @@
 		"access_key": "{{user `access_key`}}",
 		"secret_key": "{{user `secret_key`}}",
 		"region": "{{user `region`}}",
-		"source_ami": "ami-518bfb3b",
+		"source_ami": "ami-ec458981",
 		"instance_type": "t2.micro",
 		"ssh_username": "fedora",
 		"ami_name": "consul ami {{timestamp}}",

--- a/images/consul/v2/template.json
+++ b/images/consul/v2/template.json
@@ -9,7 +9,7 @@
 		"access_key": "{{user `access_key`}}",
 		"secret_key": "{{user `secret_key`}}",
 		"region": "{{user `region`}}",
-		"source_ami": "ami-518bfb3b",
+		"source_ami": "ami-ec458981",
 		"instance_type": "t2.micro",
 		"ssh_username": "fedora",
 		"ami_name": "consul ami {{timestamp}}",


### PR DESCRIPTION
actual ami is broken: impossible to upgrade packages.
I just used the latest 23 stable ami from marketplece.